### PR TITLE
Various typos and small edits in src/05-glue/02-io.md

### DIFF
--- a/src/04-markup/03-displaying_results.md
+++ b/src/04-markup/03-displaying_results.md
@@ -6,7 +6,7 @@ of our `Document` type. There are a few ways to do that:
 1. Write our own function of type `Document -> String` which we could then print, or
 2. Have Haskell write one for us
 
-Haskell provides us with mechanism that can automatically generates the implementation of a
+Haskell provides us with a mechanism that can automatically generate the implementation of a
 *type class* function called `show`, that will convert our type to `String`.
 
 The type of the function `show` looks like this:

--- a/src/04-markup/04-parsing_02.md
+++ b/src/04-markup/04-parsing_02.md
@@ -3,7 +3,7 @@
 ## Maybe
 
 Previously, when we talked about partial functions, we mentioned that one way to avoid
-writing partial functions is encode the absence of a result using `Maybe`:
+writing partial functions is to encode the absence of a result using `Maybe`:
 
 ```hs
 data Maybe a
@@ -18,7 +18,7 @@ two with the `Just` constructor to represent regular boolean values
 (`Just True` and `Just False`) and another value, `Nothing` to represent
 the absence of a boolean value.
 
-We can use this to encode the result of `head`, a function the promises to return
+We can use this to encode the result of `head`, a function that promises to return
 the first element of a list, without creating a partial function:
 
 ```hs
@@ -85,7 +85,7 @@ data EightColor
 data AnsiColor
   = AnsiColor Brightness EightColor
 
-ansiColorToVGA :: AnsiColor -> RGB
+ansiColorToVGA :: AnsiColor -> Color
 ansiColorToVGA ansicolor =
   case ansicolor of
     AnsiColor Dark Black ->
@@ -163,7 +163,7 @@ Next, instead of using a `[String]` type to denote adjacent lines, we can instea
 
 One issue we might have though with representing context with the `Structure` type,
 is that when we start parsing we don't have any context.
-But we learn of a way to represent the possibility of an absence of a value with `Maybe`! So our new context type can be `Maybe Structure` instead.
+But we learned of a way to represent the possibility of an absence of a value with `Maybe`! So our new context type can be `Maybe Structure` instead.
 
 Let's rewrite our code above to use our new context type:
 
@@ -218,7 +218,7 @@ trim = unwords . words
    Since creating new types in Haskell is cheap, this is a very viable solution.
 
    In this case I'm going with the approach of not worrying about it too much,
-   because it's a very local piece of code that can easily be fixed later if we'll see that its an issue.
+   because it's a very local piece of code that can easily be fixed later if we see that it's an issue.
 
 5. Anyway, if you've used `-Wall` like I've suggested,
    you'd get a warning from GHC saying that the *"pattern matches are non-exhaustive"*.
@@ -363,7 +363,7 @@ trim = unwords . words
 
 ### How do we know our parser works correctly?
 
-At an earlier chapter, we parsed a few example of our markup language [by hand](01-data_type.html#exercises).
+In an earlier chapter, we parsed a few examples of our markup language [by hand](01-data_type.html#exercises).
 Now, we can try to test our parser by comparing our solutions to our parser.
 By adding the `Eq` constraint to our data type (as shown in (1)), we can add these to our module and
 use the `==` (equals) operator to compare our solutions to the result our parser gives.
@@ -374,7 +374,7 @@ Try it in GHCi! You can read a text file in GHCi using the following syntax:
 ghci> txt <- readFile "/tmp/sample.txt"
 ```
 
-And then compare with a hand written example values from the solutions
+And then compare with the hand written example values from the solutions
 (after adding them to the module and loading them in GHCi):
 
 ```hs

--- a/src/05-glue/01-markup_to_html.md
+++ b/src/05-glue/01-markup_to_html.md
@@ -318,7 +318,7 @@ mconcat :: Monoid m            => [m] -> m
 ```
 
 `mconcat` is just a specialized version of `fold` for lists.
-And `fold` can be a used for any pair of data structure that implements
+And `fold` can be a used for any pair of a data structure that implements
 `Foldable` and a payload type that implements `Monoid`. This
 could be `[]` with `Structure`, or `Maybe` with `Product Int`, or
 your new shiny binary tree with `String` as the payload type. But note that

--- a/src/05-glue/02-io.md
+++ b/src/05-glue/02-io.md
@@ -5,16 +5,16 @@ string to a Haskell representation of our markup language,
 and we built an EDSL for easy writing of HTML code.
 However, our program is still not useful to other users because
 we did not make this functionality accessible to a user via some sort of
-a user interface.
+ user interface.
 
 In our program, we'd like to learn from the user what they'd
 like our program to convert to HTML, and then convert that for them.
 There are many ways to design this kind of interface, for example:
 
-- Get text as input via the *standard input*, and output HTML
+- Get text as input via the *standard input* and output HTML
   via the *standard output*
 - Receive two file names as *command-line arguments*, read the contents
-  of the first one and write the output to the second one
+  of the first one, and write the output to the second one
 - Ask for some fancier command-line arguments parsing and prefix
   the file with a flag saying what they are
 - Some fancy GUI interface
@@ -32,7 +32,7 @@ To make this interesting, we will start with the following interface:
 4. On any other kind of input, we'll output a generic message explaining
    the usage as we described above
 
-At a later chapter, we will add a little fancier command-line interface
+In a later chapter, we will add a little fancier command-line interface
 using a library, and also read whole directories and not single files.
 
 But first, we need to learn a bit about I/O in Haskell, what makes
@@ -48,9 +48,9 @@ In GHC Haskell, we use a *lazy evaluation strategy* to implement non-strict
 semantics (We've talked about laziness
 [before](../04-markup/02-parsing_01.html#laziness)).
 
-The requirement for non-strict semantics has raise an interesting challenge,
-how do we design a language that can do more than just evaluate expressions,
-how do we model interaction with the outside world? How do we do I/O?
+The requirement for non-strict semantics raises an interesting challenge:
+How do we design a language that can do more than just evaluate expressions,
+how do we model interaction with the outside world, how do we do I/O?
 
 The challenge with doing I/O operations in a language with a lazy evaluation strategy
 is that as programs grow larger, the order of evaluation becomes less trivial to
@@ -81,12 +81,12 @@ and then when we try to evaluate `-`, it requires to evaluate the two arguments
 in order from left to right, so we first evaluate `result2`.
 
 Evaluating `result2`, with substitution, means to replace occurrences of `n`
-with the input `2`, and then evaluate the top level function (`+`), it is a
-primitive function, we then evaluate its arguments, `readIntFromStdin`
-and then `n`, at this point *we are reading the first integer from the stdin*.
+with the input `2`, and then evaluate the top level function (`+`), which is a
+primitive function. We then evaluate its arguments, `readIntFromStdin`
+and then `n`; at this point *we are reading the first integer from the stdin*.
 
 After calculating the result, we can move to evaluate `result1`, in which,
-during evaluation, *will read the second integer from stdin*, this is the
+during evaluation, *will read the second integer from stdin*. This is the
 complete opposite of what we wanted!
 
 Issues like these make lazy evaluation hard to work with in the presence of
@@ -101,12 +101,12 @@ And an unfortunate consequence of impure functions is that
 The presence of impure functions makes it harder for us to reason about lazy evaluation,
 and also messes up our ability to use *equational reasoning* to understand programs.
 
-Therefore, for Haskell, it was decided to only allow **pure** functions and expressions - ones that
-have *no side effects* - pure functions will *always* return the same output (given the same input)
+Therefore, in Haskell, it was decided to only allow **pure** functions and expressions - ones that
+have *no side effects*. Pure functions will *always* return the same output (given the same input)
 and **evaluating pure expressions is deterministic**.
 
 But now, how can we do input/output operations? There are many possible solutions
-for the design space, in Haskell it was chosen to design a first class interface
+for the design space - for Haskell it was decided to design a first class interface
 with an accompanied type called `IO`. `IO`'s interface will force a distinction
 from non-I/O expressions, and will also require that in order to combine
 multiple `IO` operations, we will have to determine the order between them.
@@ -272,7 +272,7 @@ like `*>` and `>>`, `pure` is a more general version of `return`. `pure` also ha
 advantage of not having a resemblance to an unrelated keyword in other languages.
 
 Remember that we said `IO a` is description of a program
-that when executed will produce some value of type `a`, and may do some I/O effects
+that when executed will produce some value of type `a` and may do some I/O effects
 during execution?
 
 With `pure`, we can build an `IO a` that does no I/O, and will produce a
@@ -303,7 +303,7 @@ type of `>>=`:
 ```
 
 The right side of `>>=` in our code example (`\answer -> case ...`) must
-be of type `String -> IO Bool` this is because:
+be of type `String -> IO Bool`. This is because:
 
 1. `getLine :: IO String`, so the `a` in the type signature of `>>=`
    should be the same as `String` in this instance, and
@@ -391,8 +391,8 @@ with `*>` as part of the `main` expression.
 
 ## Getting out of IO?
 
-What we've seen above has great consequences to the Haskell language,
-in our `Html` type, we had a function `render :: Html -> String`
+What we've seen above has great consequences to the Haskell language.
+In our `Html` type, we had a function `render :: Html -> String`
 that could turn an `Html` to a string value.
 
 In Haskell, **there is no way** to implement a function such as `execute :: IO a -> a`
@@ -403,7 +403,7 @@ to what the Haskell API for `IO` allows us to do.
 
 This means that **we need to think about using IO differently**!
 
-In Haskell, once we got into `IO`, there is no getting out.
+In Haskell, once we get into `IO`, there is no getting out.
 The only thing we can do is build bigger IO computations by *combining*
 it with more IO computations.
 
@@ -423,7 +423,7 @@ and then print the result to the console.
 In many programming languages, we might interleave reading from the file with parsing,
 and writing to the file with the HTML conversion. But we don't mix these here.
 Parsing operates on a `String` value rather than some file handle,
-and `Html` is being convert to a `String` rather than being written to the screen directly.
+and `Html` is being converted to a `String` rather than being written to the screen directly.
 
 This approach of separating `IO` and pushing it to the edge of the program gives us
 a lot of flexibility. These functions without `IO` are easier to test and examine
@@ -431,7 +431,7 @@ a lot of flexibility. These functions without `IO` are easier to test and examin
 and they are more modular and can work in many contexts (reading from stdin,
 reading from network socket, writing to an HTTP connection, and more).
 
-This pattern is often a good approach for building Haskell programs. Especially
+This pattern is often a good approach for building Haskell programs, especially
 batch programs.
 
 ## Building a blog generator
@@ -452,7 +452,7 @@ interface:
 We are going to need a few functions:
 
 ```hs
-getArgs :: IO [String] -- get the program arguments
+getArgs :: IO [String] -- Get the program arguments
 
 getContents :: IO String -- Read all of the content from stdin
 
@@ -482,7 +482,7 @@ import System.IO (getContents, readFile, writeFile)
 ---
 
 1. Implement a function `process :: Title -> String -> String` which will parse
-a document to markup, convert it to HTML and then render the HTML to a string.
+a document to markup, convert it to HTML, and then render the HTML to a string.
 
    <details><summary>Answer</summary>
    
@@ -588,7 +588,7 @@ A *do block* starts with the `do` keyword, and continues with one or more
 And the last "statement" must be an expression of type `IO <something>` -
 this will be the result type of the do block.
 
-These construct will be translated to:
+These constructs can be translated to:
 
 1. `<expression> *>`,
 2. `let ... in` and


### PR DESCRIPTION
One additional thought. The section on "fmap and <$>" in IO combinators feels a little incomplete. Unlike the other combinators, fmap is described as alternative to using bind and pure. The reason we need fmap is more clearly described in the "Getting out of IO" section, although that discussion could point out that bind and pure also can be used. Maybe some thoughts on why one would use one over the other, or is it just a matter of taste? BTW, I think it's amazing that you're walking through how functors, applicative, and monads work and are related to each other, without talking about them explicitly!