### PR TITLE
Typos and grammar edits for Section 6

### DIFF
--- a/src/06-errors_and_files.md
+++ b/src/06-errors_and_files.md
@@ -10,7 +10,7 @@ Our HTML EDSL currently does not support links or other content modifiers such a
 We should add these so we can use them when creating an index.
 
 Up until now we've passed `String` to `Structure` creating functions such as `p_`
-and `h_`. Instead, we could create and pass them a new type, `Content`, we
+and `h_`. Instead, we could create and pass them a new type, `Content`, which
 can be regular text, links, images, and so on.
 
 ---

--- a/src/06-errors_and_files/01-either.md
+++ b/src/06-errors_and_files/01-either.md
@@ -85,8 +85,7 @@ max3chars x y z =
 
 
 The `Functor` and `Applicative` interfaces of `Either a` allow us to
-apply functions to the payload values of `Either a` types (where the `a` is the
-same type for all of the payload values) and **delay** the error handling to a
+apply functions to the payload values and **delay** the error handling to a
 later phase. Semantically, the first Either in order that returns a `Left`
 will be the return value. We can see how this works in the implementation
 of the applicative instance:

--- a/src/06-errors_and_files/01-either.md
+++ b/src/06-errors_and_files/01-either.md
@@ -100,7 +100,7 @@ instance Applicative (Either e) where
 
 At some point, someone will actually want to **inspect** the result
 and see if we got an error (with the `Left` constructor) or the expected value
-(with the `Right` constructor) by pattern matching on the result.
+(with the `Right` constructor) and they can do that by pattern matching on the result.
 
 ## Applicative + Traversable
 

--- a/src/06-errors_and_files/01-either.md
+++ b/src/06-errors_and_files/01-either.md
@@ -31,7 +31,7 @@ using an ADT.
 
 For example, let's say that we want to parse a `Char` as a decimal digit
 to an `Int`. This operation could fail if the Character is not a digit.
-We can represent this error a data type:
+We can represent this error as a data type:
 
 ```hs
 data ParseDigitError
@@ -85,8 +85,8 @@ max3chars x y z =
 
 
 The `Functor` and `Applicative` interfaces of `Either a` allow us to
-apply functions on the payload values of `Either a` types (where the `a` is the
-same between all of applied values them) and **delay** the error handling to a
+apply functions to the payload values of `Either a` types (where the `a` is the
+same type for all of the payload values) and **delay** the error handling to a
 later phase. Semantically, the first Either in order that returns a `Left`
 will be the return value. We can see how this works in the implementation
 of the applicative instance:
@@ -98,18 +98,18 @@ instance Applicative (Either e) where
     Right f <*> r = fmap f r
 ```
 
-At some point, someone who will actually want to **inspect** the result
+At some point, someone will actually want to **inspect** the result
 and see if we got an error (with the `Left` constructor) or the expected value
 (with the `Right` constructor) by pattern matching on the result.
 
 ## Applicative + Traversable
 
-The `Applicative` interface of `Either` is very powerful, and can be combine
+The `Applicative` interface of `Either` is very powerful, and can be combined
 with another abstraction called
 [`Traversable`](https://hackage.haskell.org/package/base-4.15.0.0/docs/Data-Traversable.html#g:1) -
 for data structures that can be traversed from left to right, like a linked list or a binary tree.
-With these, we can combine an unspecified amount of values such as `Either ParseDigitError Int`
-As long as they are all in a data structure that implements `Traversable`.
+With these, we can combine an unspecified amount of values such as `Either ParseDigitError Int`,
+as long as they are all in a data structure that implements `Traversable`.
 
 Let's see an example:
 
@@ -235,7 +235,7 @@ There are a few approaches, the most prominent ones are:
 
 1. Make them return the same error type. Write an ADT that holds all possible
    error descriptions. This can work in some cases but isn't always ideal
-   because for example a user calling `parseDigit` shouldn't be force to
+   because for example a user calling `parseDigit` shouldn't be forced to
    handle a possible case that the input might be an empty string.
 2. Use a specialized error type for each type, and when they are composed together,
    map the error type of each function to a more general error type. This can

--- a/src/06-errors_and_files/03-exceptions.md
+++ b/src/06-errors_and_files/03-exceptions.md
@@ -26,7 +26,7 @@ type class. By making a type an instance of the `Exception` type class, we can t
 and catch it in `IO` code:
 
 ```hs
-{-# language LambdaCase #-}
+{-# LANGUAGE LambdaCase #-}
 
 import Control.Exception
 import System.IO
@@ -78,7 +78,7 @@ main =
 >    Features such as syntactic extensions (like LambdaCase above), extensions to the type checker,
 >    and more.
 >
->    These extensions can be added by adding `{-# language <extension-name> #-}`
+>    These extensions can be added by adding `{-# LANGUAGE <extension-name> #-}`
 >    to the top of a Haskell source file, or they can be set globally for an entire project by
 >    specifying them in the
 >    [default-extensions](https://cabal.readthedocs.io/en/3.6/cabal-package.html#pkg-field-default-extensions)
@@ -119,16 +119,16 @@ Our program will crash with an error:
 ghc: <stdout>: hFlush: illegal operation (handle is closed)
 ```
 
-First, how do we know which exception we should handle? Some functions documentation
+First, how do we know which exception we should handle? Some functions' documentation
 will include this, but unfortunately `putStrLn` does not. We could guess from the
 [list of instances](https://hackage.haskell.org/package/base-4.15.0.0/docs/Control-Exception.html#i:Exception)
-the `Exception` type class has, I think
+the `Exception` type class has; I think
 [`IOException`](https://hackage.haskell.org/package/base-4.15.0.0/docs/GHC-IO-Exception.html#t:IOException) fits. Now, how can we handle this case as well? We can chain catches:
 
 ```hs
 -- need to add these at the top
 
-{-# language ScopedTypeVariables #-}
+{-# LANGUAGE ScopedTypeVariables #-}
 
 import GHC.IO.Exception (IOException(..))
 

--- a/src/06-errors_and_files/03-exceptions.md
+++ b/src/06-errors_and_files/03-exceptions.md
@@ -26,7 +26,7 @@ type class. By making a type an instance of the `Exception` type class, we can t
 and catch it in `IO` code:
 
 ```hs
-{-# LANGUAGE LambdaCase #-}
+{-# language LambdaCase #-}
 
 import Control.Exception
 import System.IO
@@ -78,7 +78,7 @@ main =
 >    Features such as syntactic extensions (like LambdaCase above), extensions to the type checker,
 >    and more.
 >
->    These extensions can be added by adding `{-# LANGUAGE <extension-name> #-}`
+>    These extensions can be added by adding `{-# language <extension-name> #-}` (the `language` part is case insensitive)
 >    to the top of a Haskell source file, or they can be set globally for an entire project by
 >    specifying them in the
 >    [default-extensions](https://cabal.readthedocs.io/en/3.6/cabal-package.html#pkg-field-default-extensions)
@@ -128,7 +128,7 @@ the `Exception` type class has; I think
 ```hs
 -- need to add these at the top
 
-{-# LANGUAGE ScopedTypeVariables #-}
+{-# language ScopedTypeVariables #-}
 
 import GHC.IO.Exception (IOException(..))
 

--- a/src/06-errors_and_files/04-implementation.md
+++ b/src/06-errors_and_files/04-implementation.md
@@ -4,9 +4,8 @@ This was a long info dump. Let's practice what we've learned. We want to:
 
 - Create the output directory
 - Grab all file names in a directory
-- Filter them according to their extension, we want to process `txt` file and
-- copy other files without modification
-- We want to parse each text file, build an index of the result,
+- Filter them according to their extension, we want to process `txt` files and copy other files without modification
+- Parse each text file, build an index of the result,
   convert the files to HTML, and write everything to the target directory
 
 
@@ -119,8 +118,7 @@ getDirFilesAndContent :: FilePath -> IO DirContents
 
 ```
 
-`getDirFilesAndContent` is responsible for providing the relevant files for processing.
-Both the ones we need to convert to markup (and their textual content) and other files we
+`getDirFilesAndContent` is responsible for providing the relevant files for processing -- both the ones we need to convert to markup (and their textual content) and other files we
 might want to copy as-is (such as images and style-sheets).
 
 ```hs
@@ -139,12 +137,12 @@ getDirFilesAndContent inputDir = do
     }
 ```
 
-This functions does 4 important things:
+This function does 4 important things:
 
-1. List all the files in the directory
-2. Split the files to 2 groups according to their file extension
-3. Read the contents of the .txt files and report when files failed to read
-4. Return the results. We've defined a data type to make what each result more obvious
+1. Lists all the files in the directory
+2. Splits the files into 2 groups according to their file extension
+3. Reads the contents of the .txt files and report when files failed to be read
+4. Returns the results. We've defined a data type to make what each result is more obvious
 
 Part (3) is a little bit more involved than the rest, lets explore it.
 
@@ -165,7 +163,7 @@ applyIoOnList action files = do
 ```
 
 `applyIoOnList` is a higher order function that applies a particular `IO` function
-(in our case `readFile`) on a list of things (In our case `FilePath`s),
+(in our case `readFile`) on a list of things (in our case `FilePath`s),
 and for each thing, it returns the thing itself along with the result of
 applying the `IO` function as an `Either`, where the `Left` side is a `String`
 representation of an error if one occurred.
@@ -252,12 +250,12 @@ createOutputDirectory dir = do
 ```
 
 `createOutputDirectoryOrExit` itself is not terribly exciting, it does
-what it is named after, it tries to create the output directory, and exits the
+what it is named -- it tries to create the output directory, and exits the
 program in case it didn't succeed.
 
 `createOutputDirectory` is the function that actually does the heavy lifting.
 It checks if the directory already exists, and checks if the user would like to
-override it. If they do, we remove it and create the new directory, if they don't,
+override it. If they do, we remove it and create the new directory; if they don't,
 we do nothing and report their decision.
 
 ### `txtsToRenderedHtml`
@@ -268,8 +266,8 @@ let
 ```
 
 In this part of the code we convert files to markup and change the
-input file paths into their respective output file paths (`.txt` -> `.html`),
-we then build the index page, and convert everything to HTML.
+input file paths to their respective output file paths (`.txt` -> `.html`).
+We then build the index page, and convert everything to HTML.
 
 ```hs
 -- | Convert text files to Markup, build an index, and render as html.
@@ -295,8 +293,8 @@ argument, just like `Either`!
 
 ### `copyFiles` and `writeFiles`
 
-The only thing left to do after the processing is completed is to write the directory
-content after processing to the newly created directory:
+The only thing left to do is to write the directory
+content, after the processing is completed, to the newly created directory:
 
 ```hs
 -- | Copy files to a directory, recording errors to stderr.
@@ -340,10 +338,10 @@ understand? Is it more modular or less? What are the pros and cons?
 ## Summary
 
 With that, we have completed our `HsBlog.Directory` module that handles converting
-a directory safely. Note that code could probably be simplified quite a bit if we
+a directory safely. Note that the code could probably be simplified quite a bit if we
 were fine with errors crashing the entire program altogether, but sometimes this is
 the price we pay for robustness. It is up to you to choose what you can live with
-and what not, but I hope this saga have taught you how to approach handling errors
+and what not, but I hope this saga has taught you how to approach handling errors
 in Haskell in case you need to.
 
 ---

--- a/src/06-errors_and_files/04-implementation.md
+++ b/src/06-errors_and_files/04-implementation.md
@@ -120,7 +120,8 @@ getDirFilesAndContent :: FilePath -> IO DirContents
 
 ```
 
-`getDirFilesAndContent` is responsible for providing the relevant files for processing -- both the ones we need to convert to markup (and their textual content) and other files we
+`getDirFilesAndContent` is responsible for providing the relevant files for processing --
+both the ones we need to convert to markup (and their textual content) and other files we
 might want to copy as-is (such as images and style-sheets).
 
 ```hs

--- a/src/06-errors_and_files/04-implementation.md
+++ b/src/06-errors_and_files/04-implementation.md
@@ -4,7 +4,9 @@ This was a long info dump. Let's practice what we've learned. We want to:
 
 - Create the output directory
 - Grab all file names in a directory
-- Filter them according to their extension, we want to process `txt` files and copy other files without modification
+- Filter them according to their extension
+- Process .txt files
+- Copy other files without modification
 - Parse each text file, build an index of the result,
   convert the files to HTML, and write everything to the target directory
 


### PR DESCRIPTION
Collected all the typos/edits for Section 6 into a single PR.

In 01-either.md (lines 88-89), I suggested a rewording. If that doesn't convey what you intended, the original phrasing was a little awkward and could be reworked.

In the summary of 03-exceptions.md, the last sentence "And also because we can only catch exceptions in `IO` code." feels like a non-sequitur. Perhaps there's more you want to say?

I really enjoyed this section. The commentary on the code helps understand idioms one sees in Haskell code and it helps to see reflections on why decisions are made, code is refactored, etc.