### PR TITLE
Fix typos in 08-testing.md

### DIFF
--- a/src/08-testing.md
+++ b/src/08-testing.md
@@ -96,7 +96,7 @@ Finished in 0.0000 seconds
 0 examples, 0 failures
 ```
 
-When we add new hspec tests (Which their filename must end with `Spec` and must expose the test `spec`),
+When we add new hspec tests (in files whose names must end with `Spec` and must expose the test `spec`),
 `hspec-discover` will find and run them automatically (though we will still need add them
 to the `other-modules` section in the cabal file).
 
@@ -262,7 +262,7 @@ and can be found in the
 
 ### Raw strings
 
-If we want to write multi-line strings, or avoid escaping string like we did in the "code"
+If we want to write multi-line strings, or avoid escaping strings like we did in the "code"
 test, we can use a library called
 [raw-strings-qq](https://hackage.haskell.org/package/raw-strings-qq)
 which uses a language extension called


### PR DESCRIPTION
A few typos/edits for 08-testing.md.
Also a few suggestions:
1. In the description of the test stanza in the cabal file, you might want to add other-modules to your description (e.g., say it’s for the test modules we write, but is commented out for now). Although you explain its use later, I find it convenient to have all the cabal stanza descriptions in one place for future reference.
2. Clarify what “expose spec” means (line 99) - I wasn't sure if it was defining spec, exporting it, etc.
3. When introducing shouldBe (lines 121-122) it might be useful to point out that the values have to be comparable, e.g., types have to implement an Eq instance. I had never updated Markup.hs and hadn't added "deriving (Eq, Show)" to the Structure type, so encountered a run time error when running the test.
