### PR TITLE
Escape strings in code_

### DIFF
--- a/src/03-html/08-exercises.md
+++ b/src/03-html/08-exercises.md
@@ -83,7 +83,7 @@ Note: the two functions above could be unified.
 
 ```hs
 code_ :: String -> Structure
-code_ = Structure . el "pre"
+code_ = Structure . el "pre" . escape
 ```
 
 </details>

--- a/src/03-html/09-summary.md
+++ b/src/03-html/09-summary.md
@@ -99,7 +99,7 @@ ol_ =
   Structure . el "ol" . concat . map (el "li" . getStructureString)
 
 code_ :: String -> Structure
-code_ = Structure . el "pre"
+code_ = Structure . el "pre" . escape
 
 append_ :: Structure -> Structure -> Structure
 append_ c1 c2 =


### PR DESCRIPTION
This should fix issue if somebody passes correct html tags  to code_.

It doesn't fix code  in `code` branch (commit [76c4f4b](https://github.com/soupi/learn-haskell-blog-generator/commit/76c4f4b31c7883c5c0b9f09c7b1a391640a31538) and others) and hard links to them in `index.md` and `src/03-html/09-summary.md`

Nice book :)