### PR TITLE
Add explicit examples of the `h_` function, 01-markup_to_html.md

### DIFF
--- a/src/05-glue/01-markup_to_html.md
+++ b/src/05-glue/01-markup_to_html.md
@@ -89,7 +89,7 @@ headings that are not `h1`. There are a few ways to handle this:
 
 ---
 
-Exercise: Implement `h_ :: Natural -> String -> Structure`.
+Exercise: Implement `h_ :: Natural -> String -> Structure` (as-in, `<h1></h1>`, `<h2></h2>`, etc).
 
 <details><summary>Solution</summary>
 

--- a/src/05-glue/01-markup_to_html.md
+++ b/src/05-glue/01-markup_to_html.md
@@ -89,7 +89,8 @@ headings that are not `h1`. There are a few ways to handle this:
 
 ---
 
-Exercise: Implement `h_ :: Natural -> String -> Structure` (as-in, `<h1></h1>`, `<h2></h2>`, etc).
+Exercise: Implement `h_ :: Natural -> String -> Structure`
+which we'll use to define arbitrary headings (such as `<h1>`, `<h2>`, and so on).
 
 <details><summary>Solution</summary>
 


### PR DESCRIPTION
I honestly had to look at the solution to remember the tags the book was referring to.

This makes it more explicit to what tag you meant, but I'm happy to change it, I'd just like it
to be more explicit.