### PR TITLE
remove invalid fields from book.toml

### DIFF
--- a/book.toml
+++ b/book.toml
@@ -5,8 +5,6 @@ authors = ["Gil Mizrahi"]
 language = "en"
 multilingual = false
 src = "src"
-git-repository-url = "https://github.com/soupi/learn-haskell-blog-generator"
-git-repository-icon = "fa-github"
 
 [output.html]
 git-repository-url = "https://github.com/soupi/learn-haskell-blog-generator"


### PR DESCRIPTION
The `git-repository-url` and `git-repository-icon` fields are only part of the `output.html` section.

See the [mdbook documantation](https://rust-lang.github.io/mdBook/format/configuration/index.html)